### PR TITLE
Added node properties secret template

### DIFF
--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -194,6 +194,17 @@ Define OTK Image Pull Secret Name
 {{- end -}}
 
 {{/*
+ Define Gateway node.properties Secret Name
+ */}}
+{{- define "gateway.node.properties" -}}
+{{- if .Values.disklessConfig.existingSecretName -}}
+    {{ .Values.disklessConfig.existingSecretName }}
+{{- else -}}
+    {{- printf "%s-%s" (include "gateway.fullname" .) "node.properties" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
  Validate OTK installation type (SINGLE, INTERNAL, DMZ)
 */}}
 {{- define "otk-install-type" -}}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -18,6 +18,7 @@ metadata:
 {{- end }}
 data:
   ACCEPT_LICENSE: {{ .Values.license.accept | quote}}
+  DISKLESS_CONFIG: {{ .Values.disklessConfig.enabled | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
 {{- if .Values.database.enabled }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -22,10 +22,12 @@ data:
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
 {{- if .Values.database.enabled }}
-  {{- if .Values.database.create }}
+  {{- if .Values.disklessConfig }}
+    {{- if .Values.database.create }}
   SSG_DATABASE_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.database.name }}
-  {{- else }}
+    {{- else }}
   SSG_DATABASE_JDBC_URL: {{ .Values.database.jdbcURL }}
+    {{- end }}
   {{- end }}
 {{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}

--- a/charts/gateway/templates/configmap.yaml
+++ b/charts/gateway/templates/configmap.yaml
@@ -21,8 +21,8 @@ data:
   DISKLESS_CONFIG: {{ .Values.disklessConfig.enabled | quote }}
   SSG_CLUSTER_HOST: {{ .Values.clusterHostname }}
   SSG_JVM_HEAP: {{ .Values.config.heapSize }}
-{{- if .Values.database.enabled }}
-  {{- if .Values.disklessConfig }}
+{{- if .Values.disklessConfig }}
+  {{- if .Values.database.enabled }}
     {{- if .Values.database.create }}
   SSG_DATABASE_JDBC_URL: jdbc:mysql://{{ .Release.Name }}-mysql:3306/{{ .Values.database.name }}
     {{- else }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -468,14 +468,14 @@ spec:
             items:
             - key: license
               path: license.xml
-  { { - if not .Values.disklessConfig.enabled } }
-        - name: { { template "gateway.fullname" . } }-node-properties
+{{ - if not .Values.disklessConfig.enabled }}
+        - name: {{ template "gateway.fullname" . } }-node-properties
           secret:
-            secretName: { { template "gateway.node.properties" . } }
+            secretName: {{ template "gateway.node.properties" . }}
             items:
               - key: node.properties
                 path: node.properties
-  { { - end } }
+{{ - end }}
         - name: {{ template "gateway.fullname" . }}-system-properties
           configMap:
             name: {{ template "gateway.fullname" . }}-configmap

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -490,14 +490,6 @@ spec:
             - key: hazelcast-xml
               path: hazelcast-client.xml
 {{- end }}
-{{ if .Values.disklessConfig  }}
-        - name: { { template "gateway.fullname" . } }-node-properties
-          secret:
-            secretName: { { template "nodePropertiesSecretName" . } }
-            items:
-              - key: node.properties
-                path: node.properties
-{{ end }}
 {{- if .Values.config.redis }}
        {{- if .Values.config.redis.enabled }}
         - name: {{ template "gateway.fullname" . }}-redis-properties

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -477,6 +477,14 @@ spec:
             - key: hazelcast-xml
               path: hazelcast-client.xml
 {{- end }}
+{{ if .Values.disklessConfig  }}
+        - name: { { template "gateway.fullname" . } }-node-properties
+          secret:
+            secretName: { { template "nodePropertiesSecretName" . } }
+            items:
+              - key: node.properties
+                path: node.properties
+{{ end }}
 {{- if .Values.config.redis }}
        {{- if .Values.config.redis.enabled }}
         - name: {{ template "gateway.fullname" . }}-redis-properties

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -192,6 +192,11 @@ spec:
             - name: {{ template "gateway.fullname" . }}-system-properties
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/system.properties
               subPath: system.properties
+{{- if not (.Values.disklessConfig.enabled) }}
+            - name: {{ template "gateway.fullname" . }}-node-properties
+              mountPath: /opt/SecureSpan/Gateway/node/default/etc/conf/node.properties
+              subPath: node.properties
+{{- end }}
 {{- if or (.Values.hazelcast.enabled) (.Values.hazelcast.external) }}
             - name: {{ template "gateway.fullname" . }}-hazelcast-client
               mountPath: /opt/SecureSpan/Gateway/node/default/etc/bootstrap/assertions/ExternalHazelcastSharedStateProviderAssertion/hazelcast-client.xml
@@ -463,6 +468,14 @@ spec:
             items:
             - key: license
               path: license.xml
+  { { - if not .Values.disklessConfig.enabled } }
+        - name: { { template "gateway.fullname" . } }-node-properties
+          secret:
+            secretName: { { template "gateway.node.properties" . } }
+            items:
+              - key: node.properties
+                path: node.properties
+  { { - end } }
         - name: {{ template "gateway.fullname" . }}-system-properties
           configMap:
             name: {{ template "gateway.fullname" . }}-configmap

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,16 +1,24 @@
-{{ if not .Values.disklessConfig  }}
+{{ if not .Values.disklessConfig.enabled }}
+{{ if not .Values.disklessConfig.existingSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name:  {{ template "nodePropertiesSecretName" . }}
+  name: {{ template "gateway.node.properties" . }}
   annotations:
-    description: Template for Secrets for Gateway node.properties
-  labels:
-    app: {{ template "gateway.name" . }}
-    chart: {{ template "gateway.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    description: Template for Secrets for the Gateway node properties
+  {{- range $key, $val := .Values.additionalAnnotations }}
+  {{ $key }}: "{{ $val }}"
+  {{- end }}
+labels:
+  app: {{ template "gateway.name" . }}
+  chart: {{ template "gateway.chart" . }}
+  release: {{ .Release.Name }}
+  heritage: {{ .Release.Service }}
+  {{- range $key, $val := .Values.additionalLabels }}
+  {{ $key }}: "{{ $val }}"
+  {{- end }}
 type: Opaque
 data:
-  node.properties: {{ .Files.Get "node.properties" | b64enc }}
+  node.properties: {{ required "Please provide a Layer7 Gateway node.properties, as disklessConfig flag is false" .Values.disklessConfig.value | b64enc | quote }}
+{{ end }}
 {{ end }}

--- a/charts/gateway/templates/node-properties-secret.yaml
+++ b/charts/gateway/templates/node-properties-secret.yaml
@@ -1,0 +1,16 @@
+{{ if not .Values.disklessConfig  }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name:  {{ template "nodePropertiesSecretName" . }}
+  annotations:
+    description: Template for Secrets for Gateway node.properties
+  labels:
+    app: {{ template "gateway.name" . }}
+    chart: {{ template "gateway.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  node.properties: {{ .Files.Get "node.properties" | b64enc }}
+{{ end }}

--- a/charts/gateway/templates/secret.yaml
+++ b/charts/gateway/templates/secret.yaml
@@ -21,13 +21,15 @@ metadata:
 {{- end }}
 type: Opaque
 data:
+{{- if .Values.disklessConfig }}
   SSG_ADMIN_USERNAME: {{ .Values.management.username | b64enc }}
   SSG_ADMIN_PASSWORD: {{ .Values.management.password | b64enc }}
   SSG_CLUSTER_PASSWORD: {{.Values.clusterPassword | b64enc }}
-{{ if .Values.database.enabled }}
+  {{ if .Values.database.enabled }}
   SSG_DATABASE_USER: {{.Values.database.username | b64enc }}
   SSG_DATABASE_PASSWORD:  {{.Values.database.password | b64enc }}
-{{ end }}
+  {{ end }}
+{{- end }}
 {{ if .Values.additionalSecret }}
 {{- range $key, $val := .Values.additionalSecret }}
   {{ $key }}: {{ $val | toString | b64enc }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -9,6 +9,13 @@ license:
   accept: false
   # existingSecretName: ssg-license
 
+# Use set diskless Configuration mode for Gateway
+# when true , get values from environment variable and on false will get values from node.properties
+disklessConfig:
+  enabled: true
+  value:
+  # existingSecretName:
+
 image:
   registry: docker.io
   repository: caapim/gateway


### PR DESCRIPTION
**Description of the change**

If disklessConfig is false , then create secret for node.properties and mount it on Gateway Container
Steps followed :

Overriding.yaml contains
`disklessConfig:
      enabled: false`

Helm install/upgrade
`helm -n dk670466-gw upgrade -i dk670466-gw --set-file "license.value=license.xml" --set "license.accept=true" --set-file "disklessConfig.value=node.properties"  -f gateway-db-diskless-values.yaml  .`


**Benefits**

When disklessConfig is false , node.properties get mounted on Gateway

**Drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #

**Additional information**


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [] Variables are documented in the README.md
- [] Title of the PR starts with chart name (e.g. `[charts/gateway]`)
- [] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

